### PR TITLE
Add LocalStack volume directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# LocalStack
+volume/


### PR DESCRIPTION
## Changes
- Add LocalStack volume directory to .gitignore to exclude temporary files and cache

## Tested
- ✅ LocalStack container startup
- ✅ S3 bucket creation
- ✅ Parameter Store operations
- ✅ Volume directory is properly ignored

## Related Issue
Closes #3
